### PR TITLE
Make immutable structs frozen

### DIFF
--- a/lib/finer_struct/immutable.rb
+++ b/lib/finer_struct/immutable.rb
@@ -4,7 +4,8 @@ module FinerStruct
 
   class Immutable
     def initialize(attributes = {})
-      @attributes = attributes.dup
+      @attributes = attributes.dup.freeze
+      freeze
     end
 
     def method_missing(method, *arguments)
@@ -19,6 +20,11 @@ module FinerStruct
   def self.Immutable(*attribute_names)
     Named.build_class(attribute_names) do
       attr_reader(*attribute_names)
+
+      def initialize(*)
+        super
+        freeze
+      end
     end
   end
 

--- a/lib/finer_struct/mutable.rb
+++ b/lib/finer_struct/mutable.rb
@@ -3,9 +3,15 @@ require 'finer_struct/named'
 
 module FinerStruct
 
-  class Mutable < Immutable
+  class Mutable
+    def initialize(attributes)
+      @attributes = attributes.dup
+    end
+
     def method_missing(method, *arguments)
-      if is_assigment?(method) && @attributes.has_key?(key_for_assignment(method))
+      if @attributes.has_key?(method)
+        @attributes[method]
+      elsif is_assigment?(method) && @attributes.has_key?(key_for_assignment(method))
         @attributes[key_for_assignment(method)] = arguments[0]
       else
         super

--- a/lib/finer_struct/named.rb
+++ b/lib/finer_struct/named.rb
@@ -1,20 +1,23 @@
 module FinerStruct
 
   module Named
+
+    def initialize(attributes = {})
+      attributes.each_pair do |name, value|
+        unless attribute_names.include?(name)
+          raise(ArgumentError, "no such attribute: #{name}")
+        end
+        instance_variable_set("@#{name}", value)
+      end
+    end
+
     def self.build_class(attribute_names, &block)
       Class.new do
         define_method(:attribute_names, -> { attribute_names })
 
-        def initialize(attributes = {})
-          attributes.each_pair do |name, value|
-            unless attribute_names.include?(name)
-              raise(ArgumentError, "no such attribute: #{name}")
-            end
-            instance_variable_set("@#{name}", value)
-          end
-        end
+        include Named
 
-        instance_eval(&block)
+        class_eval(&block)
       end
     end
   end

--- a/spec/finer_struct/immutable_spec.rb
+++ b/spec/finer_struct/immutable_spec.rb
@@ -7,6 +7,10 @@ shared_examples "an immutable struct" do
   it "complains if you try to write an attribute" do
     expect { subject.a = 3 }.to raise_error(NoMethodError)
   end
+
+  it "is frozen" do
+    subject.should be_frozen
+  end
 end
 
 module FinerStruct


### PR DESCRIPTION
This pull request makes immutable structs frozen. I had to remove the inheritance relationship between `Immutable` and `Mutable` - discuss.

Also, fixed a subtle bug in `Named.build_class` by replacing `instance_eval` with `class_eval`.
