### PR TITLE
Make FinerStruct behave like a value object

### DIFF
--- a/lib/finer_struct/immutable.rb
+++ b/lib/finer_struct/immutable.rb
@@ -1,8 +1,11 @@
 require 'finer_struct/named'
+require 'finer_struct/value_object'
 
 module FinerStruct
 
   class Immutable
+    include ValueObject
+
     def initialize(attributes = {})
       @attributes = attributes.dup.freeze
       freeze

--- a/lib/finer_struct/mutable.rb
+++ b/lib/finer_struct/mutable.rb
@@ -1,9 +1,12 @@
 require 'finer_struct/immutable'
 require 'finer_struct/named'
+require 'finer_struct/value_object'
 
 module FinerStruct
 
   class Mutable
+    include ValueObject
+
     def initialize(attributes)
       @attributes = attributes.dup
     end

--- a/lib/finer_struct/named.rb
+++ b/lib/finer_struct/named.rb
@@ -1,6 +1,9 @@
+require 'finer_struct/value_object'
+
 module FinerStruct
 
   module Named
+    include ValueObject
 
     def initialize(attributes = {})
       attributes.each_pair do |name, value|

--- a/lib/finer_struct/value_object.rb
+++ b/lib/finer_struct/value_object.rb
@@ -1,0 +1,10 @@
+module FinerStruct
+  module ValueObject
+    def ==(another_object)
+      self.class == another_object.class &&
+        self.instance_variables.all? do |ivar|
+          self.instance_variable_get(ivar) == another_object.instance_variable_get(ivar)
+      end
+    end
+  end
+end

--- a/spec/finer_struct/immutable_spec.rb
+++ b/spec/finer_struct/immutable_spec.rb
@@ -3,6 +3,7 @@ require 'finer_struct/shared_examples'
 
 shared_examples "an immutable struct" do
   it_behaves_like "a struct"
+  it_behaves_like "a value object"
 
   it "complains if you try to write an attribute" do
     expect { subject.a = 3 }.to raise_error(NoMethodError)

--- a/spec/finer_struct/mutable_spec.rb
+++ b/spec/finer_struct/mutable_spec.rb
@@ -3,6 +3,7 @@ require 'finer_struct/shared_examples'
 
 shared_examples "a mutable struct" do
   it_behaves_like "a struct"
+  it_behaves_like "a value object"
 
   it "lets you write attributes" do
     subject.a = 3

--- a/spec/finer_struct/shared_examples.rb
+++ b/spec/finer_struct/shared_examples.rb
@@ -23,3 +23,17 @@ shared_examples "a named struct" do
     expect { klass.new(c: 3) }.to raise_error(ArgumentError, "no such attribute: c")
   end
 end
+
+shared_examples "a value object" do
+  it "is equal to another object if it has the same values" do
+    another_object = subject.class.new(a: 1, b: 2)
+
+    expect(subject).to eq(another_object)
+  end
+
+  it "is not equal to another object if it has different values" do
+    another_object = subject.class.new(a: 1, b: 3)
+
+    expect(subject).not_to eq(another_object)
+  end
+end


### PR DESCRIPTION
Structs and OpenStructs are used to represent value objects, where they
are defined by their values. If we had two value objects with the same values,
that would mean they are equal. This was not the case:

```ruby
Q = FinerStruct::Immutable(:value)
a = Q.new(value:1)
=> #<Q:0x007fa1123d44c8 @value=1>
b = Q.new(value:1)
=> #<Q:0x007fa1122ed938 @value=1>
a == b
=> false
```

This PR overides the existing equality (#==) method to compare its
values to another object's values. If they are all equal it will return
true.