### PR TITLE
Simplify the named struct code

### DIFF
--- a/lib/finer_struct/immutable.rb
+++ b/lib/finer_struct/immutable.rb
@@ -22,14 +22,7 @@ module FinerStruct
   end
 
   def self.Immutable(*attribute_names)
-    Named.build_class(attribute_names) do
-      attr_reader(*attribute_names)
-
-      def initialize(*)
-        super
-        freeze
-      end
-    end
+    Named.build_class(Immutable, attribute_names)
   end
 
 end

--- a/lib/finer_struct/mutable.rb
+++ b/lib/finer_struct/mutable.rb
@@ -34,9 +34,7 @@ module FinerStruct
   end
 
   def self.Mutable(*attribute_names)
-    Named.build_class(attribute_names) do
-      attr_accessor(*attribute_names)
-    end
+    Named.build_class(Mutable, attribute_names)
   end
 
 end

--- a/lib/finer_struct/named.rb
+++ b/lib/finer_struct/named.rb
@@ -3,21 +3,19 @@ module FinerStruct
   module Named
 
     def initialize(attributes = {})
-      attributes.each_pair do |name, value|
-        unless attribute_names.include?(name)
-          raise(ArgumentError, "no such attribute: #{name}")
-        end
-        instance_variable_set("@#{name}", value)
+      unknown_attributes = attributes.keys - attribute_names
+      unless unknown_attributes.empty?
+        raise(ArgumentError, "unknown attributes: #{unknown_attributes.join(', ')}")
       end
+
+      super(attributes)
     end
 
-    def self.build_class(attribute_names, &block)
-      Class.new do
+    def self.build_class(superclass, attribute_names)
+      Class.new(superclass) do
         define_method(:attribute_names, -> { attribute_names })
 
         include Named
-
-        class_eval(&block)
       end
     end
   end

--- a/spec/finer_struct/shared_examples.rb
+++ b/spec/finer_struct/shared_examples.rb
@@ -19,7 +19,7 @@ shared_examples "a struct" do
 end
 
 shared_examples "a named struct" do
-  it "complains if you set an attribute that the struct doesn't have" do
-    expect { klass.new(c: 3) }.to raise_error(ArgumentError, "no such attribute: c")
+  it "complains if you set attributes that the struct doesn't have" do
+    expect { klass.new(c: 3, d: 4) }.to raise_error(ArgumentError, "unknown attributes: c, d")
   end
 end


### PR DESCRIPTION
The classes generated for named structs now subclass the appropriate unnamed struct classes.

For example, when you do:

     class MyStruct < FinerStruct::Immutable(:a, :b); end

`MyStruct` now has `FinerStruct::Immutable` as an ancestor.

The main win here is that it makes it easy to implement changes that affect both named and unnamed structs.