### PR TITLE
Allow aliasing of attribute methods on named structs

### DIFF
--- a/lib/finer_struct/named.rb
+++ b/lib/finer_struct/named.rb
@@ -7,15 +7,20 @@ module FinerStruct
         raise(ArgumentError, "unknown attributes: #{unknown_attributes.join(', ')}")
       end
 
-      nil_attributes = Hash[attribute_names.zip()]
-      super(nil_attributes.merge!(attributes))
+      super
     end
 
-    def self.build_class(superclass, attribute_names)
+    def self.build_class(superclass, attribute_names, &block)
       Class.new(superclass) do
+        include Named
+
         define_method(:attribute_names, -> { attribute_names })
 
-        include Named
+        attribute_names.each do |name|
+          define_method(name) { @attributes[name]  }
+        end
+
+        class_eval(&block) if block_given?
       end
     end
 

--- a/lib/finer_struct/named_mutable.rb
+++ b/lib/finer_struct/named_mutable.rb
@@ -3,6 +3,10 @@ require 'finer_struct/named'
 
 module FinerStruct
   def self.Mutable(*attribute_names)
-    Named.build_class(Mutable, attribute_names)
+    Named.build_class(Mutable, attribute_names) do
+      attribute_names.each do |name|
+        define_method(:"#{name}=") {|value| @attributes[name] = value }
+      end
+    end
   end
 end

--- a/spec/named_mutable_spec.rb
+++ b/spec/named_mutable_spec.rb
@@ -12,4 +12,13 @@ describe "a named mutable struct" do
   it_behaves_like "a struct"
   it_behaves_like "a named struct"
   it_behaves_like "a mutable struct"
+
+  it "allows you alias attribute assignments" do
+    subclass = Class.new(klass) do
+      alias_method :c=, :a=
+    end
+    struct = subclass.new(a: 1)
+    struct.c = 3
+    expect(struct.a).to eq(3)
+  end
 end

--- a/spec/shared_examples/named.rb
+++ b/spec/shared_examples/named.rb
@@ -6,4 +6,11 @@ shared_examples "a named struct" do
   it "returns nil for attributes that aren't explicitly set" do
     expect(klass.new(a: 1).b).to be_nil
   end
+
+  it "allows you to alias attributes" do
+    subclass = Class.new(klass) do
+      alias_method :c, :a
+    end
+    expect(subclass.new(a: 1).c).to eq(1)
+  end
 end


### PR DESCRIPTION
Prior to 0.0.6, named structs worked differently to anonymous structs: attributes were stored as instance variables, and accessed with individual accessor methods.

In 0.0.6, named structs started inheriting from their anonymous versions. Attributes were now stored in a hash, and accessed using `method_missing`.

An unfortunate side effect was that you could no longer call `alias_method` on attribute methods, and some folks were depending on this behaviour.

This PR puts back individual methods for attributes of named structs, but keeps the hash storage.

Fixes #11
