### PR TITLE
Align #respond_to? method signature

### DIFF
--- a/lib/finer_struct/anonymous_immutable.rb
+++ b/lib/finer_struct/anonymous_immutable.rb
@@ -14,7 +14,7 @@ module FinerStruct
       end
     end
 
-    def respond_to?(method)
+    def respond_to?(method, include_all = false)
       has_attribute?(method) || super
     end
 

--- a/lib/finer_struct/anonymous_mutable.rb
+++ b/lib/finer_struct/anonymous_mutable.rb
@@ -15,7 +15,7 @@ module FinerStruct
       end
     end
 
-    def respond_to?(method)
+    def respond_to?(method, include_all = false)
       has_attribute?(method) || super
     end
 


### PR DESCRIPTION
The [Object#respond_to](http://ruby-doc.org/core-2.3.0/Object.html#method-i-respond_to-3F) method accepts an optional second argument, `include_all`, for searching private methods. When overriding this method we should use a consistent method signature to maintain interoperability with any framework that calls this method passing the second argument.
