### PR TITLE
Support serializing named structs via YAML.

### DIFF
--- a/lib/finer_struct/anonymous_immutable.rb
+++ b/lib/finer_struct/anonymous_immutable.rb
@@ -7,7 +7,7 @@ module FinerStruct
     end
 
     def method_missing(method, *arguments)
-      if @attributes.has_key?(method)
+      if has_attribute?(method)
         @attributes[method]
       else
         super
@@ -15,7 +15,7 @@ module FinerStruct
     end
 
     def respond_to?(method)
-      @attributes.has_key?(method) || super
+      has_attribute?(method) || super
     end
 
     def to_hash
@@ -26,5 +26,10 @@ module FinerStruct
       other.class == self.class && other.to_hash == to_hash
     end
 
+  private
+
+    def has_attribute?(attribute)
+      @attributes && @attributes.has_key?(attribute)
+    end
   end
 end

--- a/lib/finer_struct/anonymous_mutable.rb
+++ b/lib/finer_struct/anonymous_mutable.rb
@@ -6,9 +6,9 @@ module FinerStruct
     end
 
     def method_missing(method, *arguments)
-      if @attributes.has_key?(method)
+      if has_attribute?(method)
         @attributes[method]
-      elsif is_assigment?(method) && @attributes.has_key?(key_for_assignment(method))
+      elsif is_assigment?(method) && has_attribute?(key_for_assignment(method))
         @attributes[key_for_assignment(method)] = arguments[0]
       else
         super
@@ -16,7 +16,7 @@ module FinerStruct
     end
 
     def respond_to?(method)
-      @attributes.has_key?(method) || super
+      has_attribute?(method) || super
     end
 
     def to_hash
@@ -37,6 +37,9 @@ module FinerStruct
       method.to_s[0..-2].to_sym
     end
 
+    def has_attribute?(attribute)
+      @attributes && @attributes.has_key?(attribute)
+    end
   end
 end
 

--- a/spec/named_immutable_spec.rb
+++ b/spec/named_immutable_spec.rb
@@ -2,9 +2,11 @@ require 'finer_struct'
 require 'shared_examples/struct'
 require 'shared_examples/named'
 require 'shared_examples/immutable'
+require 'shared_examples/serializable'
 
 describe "a named immutable struct" do
-  let(:klass) { FinerStruct::Immutable(:a, :b) }
+  TestNamedImmutableStruct = FinerStruct::Immutable(:a, :b)
+  let(:klass) { TestNamedImmutableStruct }
   subject { klass.new(a: 1, b: 2) }
   let(:identical) { klass.new(a: 1, b: 2) }
   let(:different) { klass.new(a: 3, b: 4) }
@@ -12,4 +14,5 @@ describe "a named immutable struct" do
   it_behaves_like "a struct"
   it_behaves_like "a named struct"
   it_behaves_like "an immutable struct"
+  it_behaves_like "a serializable"
 end

--- a/spec/named_mutable_spec.rb
+++ b/spec/named_mutable_spec.rb
@@ -2,9 +2,11 @@ require 'finer_struct'
 require 'shared_examples/struct'
 require 'shared_examples/named'
 require 'shared_examples/mutable'
+require 'shared_examples/serializable'
 
 describe "a named mutable struct" do
-  let(:klass) { FinerStruct::Mutable(:a, :b) }
+  TestNamedMutableStruct = FinerStruct::Mutable(:a, :b)
+  let(:klass) { TestNamedMutableStruct }
   subject { klass.new(a: 1, b: 2) }
   let(:identical) { klass.new(a: 1, b: 2) }
   let(:different) { klass.new(a: 3, b: 4) }
@@ -12,6 +14,7 @@ describe "a named mutable struct" do
   it_behaves_like "a struct"
   it_behaves_like "a named struct"
   it_behaves_like "a mutable struct"
+  it_behaves_like "a serializable"
 
   it "allows you alias attribute assignments" do
     subclass = Class.new(klass) do

--- a/spec/shared_examples/serializable.rb
+++ b/spec/shared_examples/serializable.rb
@@ -1,0 +1,15 @@
+require 'yaml'
+
+shared_examples "a serializable" do
+  it "can be serialized and de-serialized via YAML" do
+    serialized = YAML.dump(subject)
+    deserialized = YAML.load(serialized)
+    expect(deserialized).to eq(subject)
+  end
+
+  it "can be serialized and de-serialized via binary" do
+    serialized = Marshal.dump(subject)
+    deserialized = Marshal.load(serialized)
+    expect(deserialized).to eq(subject)
+  end
+end


### PR DESCRIPTION
YAML deserialization seems to call #respond_to? before instance variables have been set. This is a problem because we check `@attributes` to determine which methods we respond to.

    NoMethodError: undefined method `has_key?' for nil:NilClass
    Shared Example Group: "a serializable" called from ./spec/named_mutable_spec.rb:17
    # ./lib/finer_struct/anonymous_mutable.rb:19:in `respond_to?'
    # ./spec/shared_examples/serializable.rb:7:in `block (2 levels) in <top (required)>'

The solution proposed here introduces a check to ensure we have a non-nil `@attributes` before accessing the keys.